### PR TITLE
fix(communications): Handle JSONB as string in repositories

### DIFF
--- a/packages/backend/app/modules/communications/repositories/sms_template_repository.py
+++ b/packages/backend/app/modules/communications/repositories/sms_template_repository.py
@@ -5,6 +5,7 @@ Handles all database operations for SMS templates table.
 """
 
 import asyncpg
+import json
 from typing import Optional, List, Dict, Any
 from datetime import datetime
 from loguru import logger
@@ -316,6 +317,21 @@ class SmsTemplateRepository:
         Returns:
             SmsTemplateResponse model
         """
+        # Parse variables from JSONB - handle both string and list formats
+        variables_raw = row["variables"]
+        if variables_raw is None:
+            variables = []
+        elif isinstance(variables_raw, str):
+            # JSONB returned as string, parse it
+            try:
+                variables = json.loads(variables_raw)
+            except json.JSONDecodeError:
+                variables = []
+        elif isinstance(variables_raw, list):
+            variables = variables_raw
+        else:
+            variables = []
+
         template = SmsTemplateResponse(
             id=row["id"],
             template_code=row["template_code"],
@@ -325,7 +341,7 @@ class SmsTemplateRepository:
             content_es=row["content_es"],
             content_fr=row["content_fr"],
             content_en=row["content_en"],
-            variables=row["variables"] or [],
+            variables=variables,
             category=row["category"],
             max_segments=row["max_segments"],
             is_active=row["is_active"],

--- a/packages/backend/app/modules/communications/repositories/ussd_repository.py
+++ b/packages/backend/app/modules/communications/repositories/ussd_repository.py
@@ -362,8 +362,43 @@ class UssdRepository:
         Returns:
             UssdConfigResponse object
         """
-        # Parse JSONB fields
-        menu_structure = [MenuNode(**menu) for menu in row['menu_structure']]
+        # Parse JSONB fields - handle both string and dict/list formats
+        menu_structure_raw = row['menu_structure']
+
+        # Handle string representation of JSONB
+        if isinstance(menu_structure_raw, str):
+            try:
+                menu_structure_raw = json.loads(menu_structure_raw)
+            except json.JSONDecodeError:
+                logger.error(f"Failed to parse menu_structure JSON: {menu_structure_raw[:100]}")
+                menu_structure_raw = []
+
+        # Parse each menu node - handle nested string encoding
+        menu_structure = []
+        for menu in (menu_structure_raw or []):
+            if isinstance(menu, str):
+                try:
+                    menu = json.loads(menu)
+                except json.JSONDecodeError:
+                    logger.error(f"Failed to parse menu node: {menu[:50]}")
+                    continue
+            if isinstance(menu, dict):
+                # Also parse options if they're strings
+                if 'options' in menu and isinstance(menu['options'], str):
+                    try:
+                        menu['options'] = json.loads(menu['options'])
+                    except json.JSONDecodeError:
+                        menu['options'] = []
+                menu_structure.append(MenuNode(**menu))
+
+        auth_config_raw = row['auth_config']
+        if isinstance(auth_config_raw, str):
+            try:
+                auth_config = json.loads(auth_config_raw)
+            except json.JSONDecodeError:
+                auth_config = {}
+        else:
+            auth_config = auth_config_raw or {}
 
         return UssdConfigResponse(
             id=row['id'],
@@ -371,7 +406,7 @@ class UssdRepository:
             operator_code=row['operator_code'],
             short_code=row['short_code'],
             api_endpoint=row['api_endpoint'],
-            auth_config=row['auth_config'],
+            auth_config=auth_config,
             menu_structure=menu_structure,
             session_timeout_seconds=row['session_timeout_seconds'],
             max_input_length=row['max_input_length'],


### PR DESCRIPTION
## Summary
PostgreSQL JSONB columns may be returned as strings depending on connection settings. Added proper JSON parsing to handle both string and native Python types.

## Changes
- `sms_template_repository.py`: Parse `variables` field from JSON string to list
- `ussd_repository.py`: Parse `menu_structure` and `auth_config` fields from JSON strings

## Root cause
When asyncpg returns JSONB columns, they may come as raw strings instead of parsed Python objects, causing Pydantic validation errors like:
```
Input should be a valid list [type=list_type, input_value='["code", "expiry"]', input_type=str]
```

## Test plan
- [ ] Verify SMS templates load correctly in admin panel
- [ ] Verify USSD configurations load correctly in admin panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)