### PR TITLE
feat(payments): Phase 3 - Payment API endpoints & frontend integration

### DIFF
--- a/packages/backend/app/modules/payments/services/processors/bange_processor.py
+++ b/packages/backend/app/modules/payments/services/processors/bange_processor.py
@@ -91,7 +91,7 @@ class BangeProcessor(PaymentProcessorBase):
             )
 
             # 3. Build callback URLs
-            callback_url = f"{self.settings.api_base_url}/api/v1/webhooks/bange/callback"
+            callback_url = f"{self.settings.api_base_url}/api/v1/webhooks/bange"
             return_url = f"{self.settings.frontend_url}/dashboard/service-requests/{context.service_request_id}/payment/result"
 
             # 4. Create BANGE payment request

--- a/packages/backend/app/modules/service_requests/api/admin_routes.py
+++ b/packages/backend/app/modules/service_requests/api/admin_routes.py
@@ -2180,3 +2180,439 @@ async def cleanup_abandoned_requests(
     )
 
     return CleanupResponse(**stats)
+
+
+# ═══════════════════════════════════════════════════════════════
+# TREASURY AGENT - Payment Validation
+# ═══════════════════════════════════════════════════════════════
+
+class PaymentValidationRequest(BaseModel):
+    """Request model for agent validation."""
+    comment: Optional[str] = Field(None, max_length=500, description="Validation comment")
+
+
+class PaymentRejectionRequest(BaseModel):
+    """Request model for agent rejection."""
+    reason: str = Field(..., min_length=10, max_length=500, description="Rejection reason")
+
+
+class PaymentLockRequest(BaseModel):
+    """Request model for agent lock."""
+    duration_minutes: int = Field(
+        default=15,
+        ge=5,
+        le=60,
+        description="Lock duration in minutes (5-60)"
+    )
+
+
+class PendingPaymentResponse(BaseModel):
+    """Response for a pending payment."""
+    payment_id: str
+    payment_reference: str
+    service_request_id: Optional[str] = None
+    request_reference: Optional[str] = None
+    workflow_code: Optional[str] = None
+    user_id: str
+    user_name: Optional[str] = None
+    user_email: Optional[str] = None
+    payment_method: str
+    total_amount: float
+    currency: str = "XAF"
+    calculation_details: Optional[Dict[str, Any]] = None
+    workflow_status: str
+    locked_by_agent_id: Optional[int] = None
+    lock_expires_at: Optional[str] = None
+    created_at: str
+    hours_waiting: float
+
+
+class PendingPaymentsListResponse(BaseModel):
+    """List of pending payments."""
+    payments: List[PendingPaymentResponse]
+    total: int
+
+
+class PaymentActionResponse(BaseModel):
+    """Response for payment actions."""
+    success: bool
+    payment_id: str
+    status: str
+    message_es: Optional[str] = None
+    error: Optional[str] = None
+
+
+@router.get(
+    "/treasury/payments/pending",
+    response_model=PendingPaymentsListResponse,
+    summary="Get pending payments for validation",
+    description="""
+    Get list of payments pending Treasury Agent validation.
+
+    **Filters:**
+    - payment_method: 'cash' or 'check' (default: all manual methods)
+    - workflow_status: Filter by workflow status
+
+    **Permissions:**
+    - Requires 'treasury:validate_payments' permission
+    """
+)
+async def get_pending_payments(
+    payment_method: Optional[str] = Query(None, description="Filter by payment method"),
+    workflow_status: Optional[str] = Query(
+        "pending_agent_review",
+        description="Filter by workflow status"
+    ),
+    limit: int = Query(50, ge=1, le=100),
+    offset: int = Query(0, ge=0),
+    db: asyncpg.Connection = Depends(get_database),
+    current_user=Depends(get_current_user),
+    _=Depends(permission_required("treasury:validate_payments"))
+):
+    """Get payments pending Treasury Agent validation"""
+    from datetime import datetime
+
+    # Build query
+    where_clauses = ["sp.workflow_status = $1"]
+    params = [workflow_status or "pending_agent_review"]
+    param_idx = 2
+
+    if payment_method:
+        where_clauses.append(f"sp.payment_method = ${param_idx}")
+        params.append(payment_method)
+        param_idx += 1
+    else:
+        # Default: only manual validation methods
+        where_clauses.append(f"sp.payment_method IN ('cash', 'check')")
+
+    where_sql = " AND ".join(where_clauses)
+
+    query = f"""
+        SELECT
+            sp.id AS payment_id,
+            sp.payment_reference,
+            sp.service_request_id,
+            sr.reference_number AS request_reference,
+            sr.workflow_code,
+            sp.user_id,
+            u.first_name || ' ' || u.last_name AS user_name,
+            u.email AS user_email,
+            sp.payment_method,
+            sp.total_amount,
+            sp.currency,
+            sp.calculation_details,
+            sp.workflow_status,
+            sp.locked_by_agent_id,
+            sp.lock_expires_at,
+            sp.created_at,
+            EXTRACT(EPOCH FROM (NOW() - sp.created_at)) / 3600 AS hours_waiting
+        FROM service_payments sp
+        LEFT JOIN service_requests sr ON sr.id = sp.service_request_id
+        LEFT JOIN users u ON u.id = sp.user_id
+        WHERE {where_sql}
+        ORDER BY sp.created_at ASC
+        LIMIT ${param_idx} OFFSET ${param_idx + 1}
+    """
+    params.extend([limit, offset])
+
+    rows = await db.fetch(query, *params)
+
+    # Get total count
+    count_query = f"""
+        SELECT COUNT(*) FROM service_payments sp
+        WHERE {where_sql}
+    """
+    total = await db.fetchval(count_query, *params[:param_idx-1])
+
+    payments = []
+    for row in rows:
+        payments.append(PendingPaymentResponse(
+            payment_id=str(row["payment_id"]),
+            payment_reference=row["payment_reference"],
+            service_request_id=str(row["service_request_id"]) if row["service_request_id"] else None,
+            request_reference=row["request_reference"],
+            workflow_code=row["workflow_code"],
+            user_id=str(row["user_id"]),
+            user_name=row["user_name"],
+            user_email=row["user_email"],
+            payment_method=row["payment_method"],
+            total_amount=float(row["total_amount"]),
+            currency=row["currency"],
+            calculation_details=row["calculation_details"],
+            workflow_status=row["workflow_status"],
+            locked_by_agent_id=row["locked_by_agent_id"],
+            lock_expires_at=row["lock_expires_at"].isoformat() if row["lock_expires_at"] else None,
+            created_at=row["created_at"].isoformat(),
+            hours_waiting=float(row["hours_waiting"] or 0),
+        ))
+
+    return PendingPaymentsListResponse(
+        payments=payments,
+        total=total or 0
+    )
+
+
+@router.post(
+    "/treasury/payments/{payment_id}/lock",
+    response_model=PaymentActionResponse,
+    summary="Lock payment for review",
+    description="""
+    Lock a payment for exclusive review by this agent.
+
+    **Behavior:**
+    - Sets locked_by_agent_id to current user
+    - Sets lock_expires_at to now + duration_minutes
+    - Prevents other agents from modifying
+
+    **Permissions:**
+    - Requires 'treasury:validate_payments' permission
+    """
+)
+async def lock_payment(
+    payment_id: str = Path(..., description="Payment UUID"),
+    body: PaymentLockRequest = Body(default=PaymentLockRequest()),
+    db: asyncpg.Connection = Depends(get_database),
+    current_user=Depends(get_current_user),
+    _=Depends(permission_required("treasury:validate_payments"))
+):
+    """Lock payment for exclusive review"""
+    from datetime import datetime, timedelta
+
+    # Check if payment exists and is pending
+    payment = await db.fetchrow(
+        "SELECT id, workflow_status, locked_by_agent_id, lock_expires_at FROM service_payments WHERE id = $1",
+        payment_id
+    )
+
+    if not payment:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Payment not found: {payment_id}"
+        )
+
+    # Check if already locked by another agent
+    if payment["locked_by_agent_id"] and payment["locked_by_agent_id"] != current_user.id:
+        if payment["lock_expires_at"] and payment["lock_expires_at"] > datetime.utcnow():
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="Payment is locked by another agent"
+            )
+
+    # Lock the payment
+    lock_expires = datetime.utcnow() + timedelta(minutes=body.duration_minutes)
+
+    await db.execute(
+        """
+        UPDATE service_payments
+        SET locked_by_agent_id = $1, lock_expires_at = $2, workflow_status = 'locked_by_agent'
+        WHERE id = $3
+        """,
+        current_user.id, lock_expires, payment_id
+    )
+
+    return PaymentActionResponse(
+        success=True,
+        payment_id=payment_id,
+        status="locked_by_agent",
+        message_es=f"Pago bloqueado hasta {lock_expires.strftime('%H:%M')}"
+    )
+
+
+@router.post(
+    "/treasury/payments/{payment_id}/validate",
+    response_model=PaymentActionResponse,
+    summary="Validate payment",
+    description="""
+    Validate (approve) a cash/check payment.
+
+    **Behavior:**
+    - Sets workflow_status to 'approved'
+    - Sets validated_by_agent_id and validated_at
+    - Generates receipt_number
+    - Updates service_request payment_status
+
+    **Permissions:**
+    - Requires 'treasury:validate_payments' permission
+    - Must have lock on the payment
+    """
+)
+async def validate_payment(
+    payment_id: str = Path(..., description="Payment UUID"),
+    body: PaymentValidationRequest = Body(default=PaymentValidationRequest()),
+    db: asyncpg.Connection = Depends(get_database),
+    current_user=Depends(get_current_user),
+    _=Depends(permission_required("treasury:validate_payments"))
+):
+    """Validate (approve) a payment"""
+    from app.modules.payments.services.processors import payment_processor_registry
+
+    # Verify lock ownership
+    payment = await db.fetchrow(
+        "SELECT id, locked_by_agent_id, service_request_id FROM service_payments WHERE id = $1",
+        payment_id
+    )
+
+    if not payment:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Payment not found: {payment_id}"
+        )
+
+    if payment["locked_by_agent_id"] != current_user.id:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="You must lock the payment before validating"
+        )
+
+    # Validate via registry
+    result = await payment_processor_registry.validate_manual_payment(
+        db=db,
+        payment_id=payment_id,
+        agent_id=current_user.id,
+        comment=body.comment
+    )
+
+    if not result.paid:
+        return PaymentActionResponse(
+            success=False,
+            payment_id=payment_id,
+            status=result.status.value,
+            error=result.error
+        )
+
+    # Update service_request if linked
+    if payment["service_request_id"]:
+        await db.execute(
+            """
+            UPDATE service_requests
+            SET payment_status = 'completed', paid_at = NOW(), updated_at = NOW()
+            WHERE id = $1
+            """,
+            payment["service_request_id"]
+        )
+
+    return PaymentActionResponse(
+        success=True,
+        payment_id=payment_id,
+        status="approved",
+        message_es="Pago validado correctamente. Recibo generado."
+    )
+
+
+@router.post(
+    "/treasury/payments/{payment_id}/reject",
+    response_model=PaymentActionResponse,
+    summary="Reject payment",
+    description="""
+    Reject a cash/check payment.
+
+    **Behavior:**
+    - Sets workflow_status to 'rejected'
+    - Records rejection reason
+    - Notifies user
+
+    **Permissions:**
+    - Requires 'treasury:validate_payments' permission
+    - Must have lock on the payment
+    """
+)
+async def reject_payment(
+    payment_id: str = Path(..., description="Payment UUID"),
+    body: PaymentRejectionRequest = ...,
+    db: asyncpg.Connection = Depends(get_database),
+    current_user=Depends(get_current_user),
+    _=Depends(permission_required("treasury:validate_payments"))
+):
+    """Reject a payment"""
+    from app.modules.payments.services.processors import payment_processor_registry
+
+    # Verify lock ownership
+    payment = await db.fetchrow(
+        "SELECT id, locked_by_agent_id FROM service_payments WHERE id = $1",
+        payment_id
+    )
+
+    if not payment:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Payment not found: {payment_id}"
+        )
+
+    if payment["locked_by_agent_id"] != current_user.id:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="You must lock the payment before rejecting"
+        )
+
+    # Reject via registry
+    result = await payment_processor_registry.reject_manual_payment(
+        db=db,
+        payment_id=payment_id,
+        agent_id=current_user.id,
+        reason=body.reason
+    )
+
+    return PaymentActionResponse(
+        success=True,
+        payment_id=payment_id,
+        status="rejected",
+        message_es="Pago rechazado."
+    )
+
+
+@router.post(
+    "/treasury/payments/{payment_id}/unlock",
+    response_model=PaymentActionResponse,
+    summary="Release payment lock",
+    description="""
+    Release lock on a payment without validating.
+
+    **Behavior:**
+    - Clears locked_by_agent_id and lock_expires_at
+    - Returns status to 'pending_agent_review'
+
+    **Permissions:**
+    - Requires 'treasury:validate_payments' permission
+    - Must be the agent who locked it
+    """
+)
+async def unlock_payment(
+    payment_id: str = Path(..., description="Payment UUID"),
+    db: asyncpg.Connection = Depends(get_database),
+    current_user=Depends(get_current_user),
+    _=Depends(permission_required("treasury:validate_payments"))
+):
+    """Release lock on a payment"""
+    # Verify ownership
+    payment = await db.fetchrow(
+        "SELECT id, locked_by_agent_id FROM service_payments WHERE id = $1",
+        payment_id
+    )
+
+    if not payment:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Payment not found: {payment_id}"
+        )
+
+    if payment["locked_by_agent_id"] != current_user.id:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="You can only unlock payments you locked"
+        )
+
+    await db.execute(
+        """
+        UPDATE service_payments
+        SET locked_by_agent_id = NULL, lock_expires_at = NULL, workflow_status = 'pending_agent_review'
+        WHERE id = $1
+        """,
+        payment_id
+    )
+
+    return PaymentActionResponse(
+        success=True,
+        payment_id=payment_id,
+        status="pending_agent_review",
+        message_es="Bloqueo liberado."
+    )

--- a/packages/backend/app/modules/service_requests/api/routes.py
+++ b/packages/backend/app/modules/service_requests/api/routes.py
@@ -23,7 +23,12 @@ from ..models.service_request import (
     CitizenSummaryResponse,
     ValidationResultResponse,
     PaymentStatusResponse,
+    PaymentMethodInfo,
+    PaymentMethodsResponse,
+    PaymentInitiateRequest,
+    PaymentInitiateResponse,
 )
+from ..models.enums import ServiceRequestStatus
 from fastapi import HTTPException, status
 from ..services.service_request_service import service_request_service
 from app.database.connection import get_database
@@ -887,6 +892,183 @@ async def get_payment_status(
         currency=currency,
         payment_method=request.form_data.get("payment_method") if request.form_data else None,
         completed_at=request.paid_at,
+    )
+
+
+# ═══════════════════════════════════════════════════════════════
+# PAYMENT METHODS & INITIATION
+# ═══════════════════════════════════════════════════════════════
+
+@router.get(
+    "/{request_id}/payment/methods",
+    response_model=PaymentMethodsResponse,
+    summary="Get available payment methods",
+    description="""
+    Get the list of available payment methods for this service request.
+
+    Returns all payment methods that can be used to pay for this request,
+    with labels in multiple languages and processor information.
+    """
+)
+async def get_payment_methods(
+    request_id: UUID = Path(..., description="The service request ID"),
+    db: asyncpg.Connection = Depends(get_database),
+    current_user=Depends(get_current_user)
+) -> PaymentMethodsResponse:
+    """Get available payment methods for this service request"""
+    from app.modules.payments.services.processors import payment_processor_registry
+
+    # Verify request exists and belongs to user
+    request = await service_request_service.get_request(
+        db=db,
+        request_id=request_id,
+        user_id=current_user.id
+    )
+
+    if not request:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Service request not found: {request_id}"
+        )
+
+    # Get available methods from registry
+    methods_info = payment_processor_registry.get_methods_info()
+
+    # Convert to response models
+    methods = [
+        PaymentMethodInfo(
+            code=m["code"],
+            label_es=m["label_es"],
+            label_en=m["label_en"],
+            label_fr=m["label_fr"],
+            processor_type=m["processor_type"],
+            requires_phone=m["requires_phone"],
+            requires_redirect=m["requires_redirect"],
+            requires_agent_validation=m["requires_agent_validation"],
+        )
+        for m in methods_info
+    ]
+
+    # Default to mobile_money if available
+    default_method = "mobile_money" if any(m.code == "mobile_money" for m in methods) else None
+
+    return PaymentMethodsResponse(
+        methods=methods,
+        default_method=default_method
+    )
+
+
+@router.post(
+    "/{request_id}/payment/initiate",
+    response_model=PaymentInitiateResponse,
+    summary="Initiate payment",
+    description="""
+    Initiate payment for a service request.
+
+    **Payment Methods:**
+    - `mobile_money`: MTN/Orange Mobile Money via BANGE API (requires phone_number)
+    - `card`: Bank card via BANGE Gateway (returns redirect_url)
+    - `bank_transfer`: Bank transfer via BANGE
+    - `cash`: Cash payment (requires agent validation)
+    - `check`: Check payment (requires agent validation)
+
+    **Response:**
+    - For BANGE payments: `redirect_url` to complete payment
+    - For cash/check: `action_type='agent_validation'`, wait for agent confirmation
+    """
+)
+async def initiate_payment(
+    request_id: UUID = Path(..., description="The service request ID"),
+    body: PaymentInitiateRequest = ...,
+    db: asyncpg.Connection = Depends(get_database),
+    current_user=Depends(get_current_user)
+) -> PaymentInitiateResponse:
+    """Initiate payment for a service request"""
+    from app.modules.payments.services.processors import payment_processor_registry
+    from app.modules.payments.services.processors.base import PaymentContext
+    from app.modules.payments.models.payment import PaymentMethod
+
+    # Load context
+    context = await workflow_engine.load_context_from_db(db, request_id)
+    if not context:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Service request not found: {request_id}"
+        )
+
+    # Verify ownership
+    if str(context.user_id) != str(current_user.id):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Access denied"
+        )
+
+    # Verify request is in correct status for payment
+    if context.status not in [ServiceRequestStatus.PAYMENT_PENDING]:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Cannot initiate payment in status: {context.status.value}"
+        )
+
+    # Validate payment method
+    try:
+        payment_method = PaymentMethod(body.payment_method)
+    except ValueError:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Invalid payment method: {body.payment_method}"
+        )
+
+    # Validate phone for mobile money
+    if payment_method == PaymentMethod.MOBILE_MONEY and not body.phone_number:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Phone number is required for Mobile Money payments"
+        )
+
+    # Get tariff amount from context
+    from ..services.tariff_calculator import tariff_calculator
+    workflow = workflow_engine.get_workflow(context.workflow_code)
+    tariff_breakdown = await tariff_calculator.calculate(db, workflow, context)
+    total_amount = tariff_breakdown.get("total_amount", 0)
+
+    if total_amount <= 0:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="No payment required for this request"
+        )
+
+    # Create payment context
+    from decimal import Decimal
+    payment_context = PaymentContext(
+        service_request_id=str(request_id),
+        user_id=str(current_user.id),
+        amount=Decimal(str(total_amount)),
+        currency=tariff_breakdown.get("currency", "XAF"),
+        payment_method=payment_method,
+        tariff_breakdown=tariff_breakdown,
+        user_email=current_user.email,
+        user_phone=body.phone_number or current_user.phone,
+        user_name=f"{current_user.first_name} {current_user.last_name}".strip(),
+        workflow_code=context.workflow_code.value,
+        service_name=workflow.service_name_es if workflow else None,
+        reference_number=context.reference_number,
+    )
+
+    # Initiate payment via registry
+    result = await payment_processor_registry.initiate_payment(db, payment_context)
+
+    return PaymentInitiateResponse(
+        success=result.success,
+        payment_id=result.payment_id,
+        payment_reference=result.external_reference,
+        status=result.status.value if hasattr(result.status, "value") else str(result.status),
+        redirect_url=result.redirect_url,
+        requires_action=result.requires_action,
+        action_type=result.action_type,
+        message_es=result.message_es,
+        expires_at=result.expires_at,
+        error=result.error,
     )
 
 

--- a/packages/backend/app/modules/service_requests/models/service_request.py
+++ b/packages/backend/app/modules/service_requests/models/service_request.py
@@ -638,3 +638,46 @@ class PaymentStatusResponse(BaseModel):
         default=None,
         description="When payment was completed"
     )
+
+
+# ===================================================================
+# PAYMENT METHODS & INITIATION
+# ===================================================================
+
+class PaymentMethodInfo(BaseModel):
+    """Information about a single payment method."""
+    code: str = Field(..., description="Payment method code")
+    label_es: str = Field(..., description="Spanish label")
+    label_en: str = Field(..., description="English label")
+    label_fr: str = Field(..., description="French label")
+    processor_type: str = Field(..., description="Processor type: bange_api or manual")
+    requires_phone: bool = Field(default=False, description="Whether phone number is required")
+    requires_redirect: bool = Field(default=False, description="Whether redirect to payment gateway")
+    requires_agent_validation: bool = Field(default=False, description="Whether agent validation needed")
+
+
+class PaymentMethodsResponse(BaseModel):
+    """Response with available payment methods."""
+    methods: List[PaymentMethodInfo] = Field(..., description="List of available payment methods")
+    default_method: Optional[str] = Field(default=None, description="Recommended default method")
+
+
+class PaymentInitiateRequest(BaseModel):
+    """Request to initiate a payment."""
+    payment_method: str = Field(..., description="Payment method code")
+    phone_number: Optional[str] = Field(None, description="Phone number for Mobile Money")
+    return_url: Optional[str] = Field(None, description="URL to redirect after payment")
+
+
+class PaymentInitiateResponse(BaseModel):
+    """Response after initiating payment."""
+    success: bool = Field(..., description="Whether initiation was successful")
+    payment_id: str = Field(..., description="Internal payment ID")
+    payment_reference: Optional[str] = Field(None, description="External reference")
+    status: str = Field(..., description="Initial payment status")
+    redirect_url: Optional[str] = Field(None, description="URL to redirect for payment")
+    requires_action: bool = Field(default=False, description="Whether user action is required")
+    action_type: Optional[str] = Field(None, description="Type of action required")
+    message_es: Optional[str] = Field(None, description="Message for user in Spanish")
+    expires_at: Optional[datetime] = Field(None, description="When this payment request expires")
+    error: Optional[str] = Field(None, description="Error message if success=false")

--- a/packages/backend/app/modules/webhooks/api/webhook_routes.py
+++ b/packages/backend/app/modules/webhooks/api/webhook_routes.py
@@ -105,17 +105,28 @@ async def bange_webhook_callback(
 
     logger.info(f"BANGE webhook received: {payload.bank_reference}, transaction_id: {transaction_id}")
 
-    # Try auto-reconciliation (match by bank_reference)
-    if payload.merchant_reference:  # Our payment.bank_reference
+    # Try auto-reconciliation (match by merchant_reference)
+    if payload.merchant_reference:
         try:
+            # First try service_payments (service requests - passport, residence, etc.)
+            service_reconciled = await reconcile_service_payment(
+                db,
+                payload.merchant_reference,
+                payload.bank_reference
+            )
+            if service_reconciled:
+                logger.info(f"Auto-reconciled transaction {transaction_id} with service_payment")
+                return {"message": "Transaction processed and reconciled (service_payment)", "transaction_id": transaction_id}
+
+            # Then try payments table (tax declarations)
             reconciled = await repository.auto_reconcile_by_reference(db, payload.merchant_reference)
             if reconciled:
                 logger.info(f"Auto-reconciled transaction {transaction_id} with payment")
-                
+
                 # Confirm appointment hold if this payment is for a service_request
                 if reconciled.get("payment_id"):
                     await confirm_appointment_for_payment(db, str(reconciled["payment_id"]))
-                
+
                 return {"message": "Transaction processed and reconciled", "transaction_id": transaction_id}
         except Exception as e:
             logger.warning(f"Auto-reconciliation failed: {e}, will require manual reconciliation")
@@ -152,6 +163,55 @@ async def confirm_appointment_for_payment(db, payment_id: str):
     except Exception as e:
         logger.error(f"Error confirming appointment for payment {payment_id}: {e}")
 
+
+
+
+async def reconcile_service_payment(db, merchant_reference: str, bange_transaction_id: str) -> bool:
+    """
+    Reconcile a service_payment based on merchant_reference (our payment_reference).
+    Called by BANGE webhook to mark payments as completed.
+    """
+    try:
+        query = """
+            SELECT id, service_request_id, status
+            FROM service_payments
+            WHERE payment_reference = $1
+            AND status IN ('pending', 'processing')
+        """
+        payment = await db.fetchrow(query, merchant_reference)
+
+        if not payment:
+            logger.debug(f"No pending service_payment found with reference {merchant_reference}")
+            return False
+
+        payment_id = str(payment["id"])
+        service_request_id = payment["service_request_id"]
+
+        update_query = """
+            UPDATE service_payments
+            SET status = 'completed',
+                workflow_status = 'completed',
+                paid_at = NOW(),
+                bange_transaction_id = $2,
+                updated_at = NOW()
+            WHERE id = $1
+        """
+        await db.execute(update_query, payment_id, bange_transaction_id)
+
+        if service_request_id:
+            await db.execute(
+                "UPDATE service_requests SET payment_status = 'completed', paid_at = NOW(), updated_at = NOW() WHERE id = $1",
+                service_request_id
+            )
+            logger.info(f"Updated service_request {service_request_id} payment_status to completed")
+            await confirm_appointment_for_payment(db, payment_id)
+
+        logger.info(f"Service payment {payment_id} reconciled with BANGE transaction {bange_transaction_id}")
+        return True
+
+    except Exception as e:
+        logger.error(f"Error reconciling service_payment with reference {merchant_reference}: {e}")
+        return False
 
 @router.get("/transactions/unreconciled", response_model=BankTransactionListResponse)
 async def list_unreconciled_transactions(

--- a/packages/web/src/app/[locale]/(dashboard)/dashboard/service-requests/[id]/wizard/page.tsx
+++ b/packages/web/src/app/[locale]/(dashboard)/dashboard/service-requests/[id]/wizard/page.tsx
@@ -74,13 +74,14 @@ import type {
   PassportSolicitudType,
   PassportRenovacionMotivo,
   DocumentExtractionPreview,
+  PaymentMethodInfo,
 } from '@/modules/service-requests'
 import {
   DocumentConditionType,
   PASSPORT_WIZARD_STEPS,
   PASSPORT_TARIFFS,
 } from '@/modules/service-requests'
-import { PaymentMethod, getPaymentMethodLabel } from '@/types/payment'
+import { PaymentMethod } from '@/types/payment'
 
 // Use shared constants from types/index.ts
 const WIZARD_STEPS = PASSPORT_WIZARD_STEPS
@@ -134,6 +135,7 @@ export default function PassportWizardPage() {
     getCitizenSummary,
     downloadSummaryPDF,
     // Payment methods
+    getPaymentMethods,
     initiatePayment,
     checkPaymentStatus,
     // Appointment methods
@@ -149,6 +151,8 @@ export default function PassportWizardPage() {
   const [phoneNumber, setPhoneNumber] = useState('')
   const [isProcessingPayment, setIsProcessingPayment] = useState(false)
   const [paymentComplete, setPaymentComplete] = useState(false)
+  const [availablePaymentMethods, setAvailablePaymentMethods] = useState<PaymentMethodInfo[]>([])
+  const [isLoadingPaymentMethods, setIsLoadingPaymentMethods] = useState(false)
   const paymentPollRef = useRef<NodeJS.Timeout | null>(null)
 
   // Document preview state - stores extraction data from 2-step flow
@@ -730,6 +734,38 @@ export default function PassportWizardPage() {
   // PAYMENT WITH STATUS POLLING
   // ==========================================================================
 
+  // Load payment methods when step becomes payment
+  const loadPaymentMethods = useCallback(async () => {
+    setIsLoadingPaymentMethods(true)
+    try {
+      const response = await getPaymentMethods()
+      if (response) {
+        setAvailablePaymentMethods(response.methods)
+        // Set default if specified
+        if (response.defaultMethod) {
+          setSelectedPaymentMethod(response.defaultMethod as PaymentMethod)
+        }
+      }
+    } catch (err) {
+      console.error('Failed to load payment methods:', err)
+      // Fallback to default methods
+      setAvailablePaymentMethods([
+        { code: PaymentMethod.MOBILE_MONEY, labelEs: 'Mobile Money', labelEn: 'Mobile Money', labelFr: 'Mobile Money', processorType: 'bange_api', requiresPhone: true, requiresRedirect: true, requiresAgentValidation: false },
+        { code: PaymentMethod.CASH, labelEs: 'Efectivo', labelEn: 'Cash', labelFr: 'Especes', processorType: 'manual', requiresPhone: false, requiresRedirect: false, requiresAgentValidation: true },
+      ])
+    } finally {
+      setIsLoadingPaymentMethods(false)
+    }
+  }, [getPaymentMethods])
+
+  // Load payment methods when reaching payment step
+  useEffect(() => {
+    const step = WIZARD_STEPS[currentStepIndex]
+    if (step?.id === 'payment' && availablePaymentMethods.length === 0 && !isLoadingPaymentMethods) {
+      loadPaymentMethods()
+    }
+  }, [currentStepIndex, availablePaymentMethods.length, isLoadingPaymentMethods, loadPaymentMethods])
+
   const handlePayment = async () => {
     if (!selectedPaymentMethod) return
 
@@ -979,6 +1015,8 @@ export default function PassportWizardPage() {
         <PaymentStepImproved
           locale={locale}
           tariff={getTariff()}
+          availableMethods={availablePaymentMethods}
+          isLoadingMethods={isLoadingPaymentMethods}
           selectedMethod={selectedPaymentMethod}
           phoneNumber={phoneNumber}
           isProcessing={isProcessingPayment}
@@ -1981,6 +2019,8 @@ function ValidationStepImproved({ locale, validationResults, isValidating, onRev
 interface PaymentStepImprovedProps {
   locale: string
   tariff: number
+  availableMethods: PaymentMethodInfo[]
+  isLoadingMethods: boolean
   selectedMethod: PaymentMethod | null
   phoneNumber: string
   isProcessing: boolean
@@ -1995,6 +2035,8 @@ interface PaymentStepImprovedProps {
 function PaymentStepImproved({
   locale,
   tariff,
+  availableMethods,
+  isLoadingMethods,
   selectedMethod,
   phoneNumber,
   isProcessing,
@@ -2005,10 +2047,17 @@ function PaymentStepImproved({
   onNext,
   onBack,
 }: PaymentStepImprovedProps) {
-  const availableMethods = [
-    { method: PaymentMethod.MOBILE_MONEY, icon: Smartphone, requiresPhone: true },
-    { method: PaymentMethod.CASH, icon: Banknote, requiresPhone: false },
-  ]
+  // Get icon for method code
+  const getMethodIcon = (code: string) => {
+    const icons: Record<string, React.ComponentType<{ className?: string }>> = {
+      mobile_money: Smartphone,
+      cash: Banknote,
+      check: Banknote,
+      card: CreditCard,
+      bank_transfer: Banknote,
+    }
+    return icons[code] || Banknote
+  }
 
   const texts = {
     es: {
@@ -2054,8 +2103,9 @@ function PaymentStepImproved({
 
   const t = texts[locale as keyof typeof texts] || texts.es
 
+  const selectedMethodInfo = availableMethods.find(m => m.code === selectedMethod)
   const canPay = selectedMethod !== null &&
-    (!availableMethods.find(m => m.method === selectedMethod)?.requiresPhone || phoneNumber.length >= 9)
+    (!selectedMethodInfo?.requiresPhone || phoneNumber.length >= 9)
 
   if (paymentComplete) {
     return (
@@ -2091,25 +2141,41 @@ function PaymentStepImproved({
         {/* Payment Method Selection */}
         <div className="space-y-3">
           <Label>{t.selectMethod}</Label>
-          <RadioGroup
-            value={selectedMethod || ''}
-            onValueChange={(value) => onMethodSelect(value as PaymentMethod)}
-            disabled={isProcessing}
-          >
-            {availableMethods.map(({ method, icon: Icon }) => (
-              <div key={method} className="flex items-center space-x-3">
-                <RadioGroupItem value={method} id={method} />
-                <Label htmlFor={method} className="flex items-center gap-2 cursor-pointer">
-                  <Icon className="h-5 w-5" />
-                  {getPaymentMethodLabel(method)}
-                </Label>
-              </div>
-            ))}
-          </RadioGroup>
+          {isLoadingMethods ? (
+            <div className="flex items-center gap-2 text-muted-foreground">
+              <Loader2 className="h-4 w-4 animate-spin" />
+              <span>{locale === 'es' ? 'Cargando metodos...' : locale === 'fr' ? 'Chargement...' : 'Loading methods...'}</span>
+            </div>
+          ) : (
+            <RadioGroup
+              value={selectedMethod || ''}
+              onValueChange={(value) => onMethodSelect(value as PaymentMethod)}
+              disabled={isProcessing}
+            >
+              {availableMethods.map((method) => {
+                const Icon = getMethodIcon(method.code)
+                const label = locale === 'es' ? method.labelEs : locale === 'fr' ? method.labelFr : method.labelEn
+                return (
+                  <div key={method.code} className="flex items-center space-x-3">
+                    <RadioGroupItem value={method.code} id={method.code} />
+                    <Label htmlFor={method.code} className="flex items-center gap-2 cursor-pointer">
+                      <Icon className="h-5 w-5" />
+                      {label}
+                      {method.requiresAgentValidation && (
+                        <span className="text-xs text-muted-foreground">
+                          ({locale === 'es' ? 'validacion manual' : locale === 'fr' ? 'validation manuelle' : 'manual validation'})
+                        </span>
+                      )}
+                    </Label>
+                  </div>
+                )
+              })}
+            </RadioGroup>
+          )}
         </div>
 
-        {/* Phone Number (for Mobile Money) */}
-        {selectedMethod === PaymentMethod.MOBILE_MONEY && (
+        {/* Phone Number (for methods requiring phone) */}
+        {selectedMethodInfo?.requiresPhone && (
           <div className="space-y-2">
             <Label htmlFor="phone">{t.phoneLabel}</Label>
             <Input

--- a/packages/web/src/modules/service-requests/hooks/useServiceRequests.ts
+++ b/packages/web/src/modules/service-requests/hooks/useServiceRequests.ts
@@ -23,6 +23,7 @@ import type {
   EntityLocation,
   AvailableSlot,
   AppointmentHoldStatus,
+  PaymentMethodsResponse,
 } from '../types'
 
 // ============================================================================
@@ -84,6 +85,7 @@ export interface UseServiceRequestsReturn {
 
   // Submission
   submitRequest: () => Promise<boolean>
+  getPaymentMethods: () => Promise<PaymentMethodsResponse | null>
   initiatePayment: (method: string, phone?: string) => Promise<{ paymentId: string; redirectUrl?: string } | null>
   checkPaymentStatus: () => Promise<{ status: string; paid: boolean } | null>
 
@@ -595,6 +597,21 @@ export function useServiceRequests(): UseServiceRequestsReturn {
     }
   }, [currentRequest, handleError])
 
+  const getPaymentMethods = useCallback(async (): Promise<PaymentMethodsResponse | null> => {
+    if (!currentRequest) return null
+
+    try {
+      setIsLoading(true)
+      setError(null)
+      return await serviceRequestsApi.getPaymentMethods(currentRequest.id)
+    } catch (err) {
+      handleError(err)
+      return null
+    } finally {
+      setIsLoading(false)
+    }
+  }, [currentRequest, handleError])
+
   const initiatePayment = useCallback(async (
     method: string,
     phone?: string
@@ -968,6 +985,7 @@ export function useServiceRequests(): UseServiceRequestsReturn {
 
     // Submission
     submitRequest,
+    getPaymentMethods,
     initiatePayment,
     checkPaymentStatus,
 

--- a/packages/web/src/modules/service-requests/services/api.ts
+++ b/packages/web/src/modules/service-requests/services/api.ts
@@ -26,6 +26,8 @@ import type {
   CitizenSummaryResponse,
   FieldIndicator,
   RiskAnalysisResult,
+  // Payment types
+  PaymentMethodsResponse,
 } from '../types'
 import { ExtractionStatus } from '../types'
 
@@ -898,6 +900,42 @@ class ServiceRequestsApiClient {
       method: 'POST',
     })
     return transformServiceRequest(backend)
+  }
+
+  /**
+   * Get available payment methods for request
+   */
+  async getPaymentMethods(requestId: string): Promise<PaymentMethodsResponse> {
+    interface BackendPaymentMethod {
+      code: string
+      label_es: string
+      label_en: string
+      label_fr: string
+      processor_type: string
+      requires_phone: boolean
+      requires_redirect: boolean
+      requires_agent_validation: boolean
+    }
+    interface BackendResponse {
+      methods: BackendPaymentMethod[]
+      default_method: string | null
+    }
+
+    const backend = await this.request<BackendResponse>(`/${requestId}/payment/methods`)
+
+    return {
+      methods: backend.methods.map(m => ({
+        code: m.code,
+        labelEs: m.label_es,
+        labelEn: m.label_en,
+        labelFr: m.label_fr,
+        processorType: m.processor_type as 'bange_api' | 'manual',
+        requiresPhone: m.requires_phone,
+        requiresRedirect: m.requires_redirect,
+        requiresAgentValidation: m.requires_agent_validation,
+      })),
+      defaultMethod: backend.default_method,
+    }
   }
 
   /**

--- a/packages/web/src/modules/service-requests/types/index.ts
+++ b/packages/web/src/modules/service-requests/types/index.ts
@@ -602,6 +602,32 @@ export function getStepTypeIcon(stepType: StepType): string {
 }
 
 // ============================================================================
+// PAYMENT METHOD TYPES
+// ============================================================================
+
+/**
+ * PaymentMethodInfo - Information about a payment method from the API
+ */
+export interface PaymentMethodInfo {
+  code: string
+  labelEs: string
+  labelEn: string
+  labelFr: string
+  processorType: 'bange_api' | 'manual'
+  requiresPhone: boolean
+  requiresRedirect: boolean
+  requiresAgentValidation: boolean
+}
+
+/**
+ * PaymentMethodsResponse - Response from GET /payment/methods
+ */
+export interface PaymentMethodsResponse {
+  methods: PaymentMethodInfo[]
+  defaultMethod: string | null
+}
+
+// ============================================================================
 // APPOINTMENT TYPES (Citizen-First Flow)
 // ============================================================================
 


### PR DESCRIPTION
## Summary
- Add payment API endpoints (`GET /{id}/payment/methods` and `POST /{id}/payment/initiate`)
- Add Treasury Agent dashboard endpoints for payment validation workflow
- Add service_payments reconciliation to BANGE webhook handler
- Replace hardcoded payment methods with dynamic API loading in wizard
- Add multi-language labels support (es/en/fr) for payment methods

## Changes
### Backend
- Add `PaymentMethodInfo` response model
- Add payment/methods endpoint returning available payment methods
- Add payment/initiate endpoint for starting payment flow
- Add Treasury Agent endpoints for payment validation
- Add `reconcile_service_payment` function to webhook routes
- Fix BANGE callback URL construction

### Frontend
- Add `PaymentMethodInfo` and `PaymentMethodsResponse` types
- Add `getPaymentMethods` to API service with snake_case transformation
- Add `getPaymentMethods` to useServiceRequests hook
- Replace hardcoded payment methods array with dynamic API loading
- Add loading state and fallback mechanism
- Support labels from API for es/en/fr locales

## Test Plan
- [x] TypeScript builds without errors
- [x] ESLint passes with < 100 warnings
- [x] CI tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)